### PR TITLE
That space forces browser to mutate DOM

### DIFF
--- a/src/js/react-datatable/column.js
+++ b/src/js/react-datatable/column.js
@@ -13,7 +13,7 @@ var RDTColumn = React.createClass({
         var cols = this.props.config.cols;
         return(
             <thead>
-                <tr> {
+                <tr>{
                     cols.map(function(col,idx) {
                         return <td key={idx + 100}>{col.header}</td>
                     })


### PR DESCRIPTION
And i get a message
`Error: Invariant Violation: processUpdates(): Unable to find child 4 of element. This probably means the DOM was unexpectedly mutated (e.g., by the browser), usually due to forgetting a <tbody> when using tables, nesting tags like <form>, <p>, or <a>, or using non-SVG elements in an <svg> parent. Try inspecting the child nodes of the element with React ID .0.1.0.1.0.0.0.0.0.0.0.0.`
